### PR TITLE
Add a name to the background group

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -536,6 +536,7 @@ export class PlatformGnomeShell extends AbstractPlatform {
 
     initBackground() {
     	this._backgroundGroup = new Meta.BackgroundGroup();
+        this._backgroundGroup.set_name("coverflow-alt-tab-background-group");
         Main.layoutManager.uiGroup.add_child(this._backgroundGroup);
     	if (this._backgroundGroup.lower_bottom) {
 	        this._backgroundGroup.lower_bottom();


### PR DESCRIPTION
Add a name to the background group actor so that other Gnome extensions may utilize the name to find and customize the background effects of the switcher.

Related to https://github.com/aunetx/blur-my-shell/pull/633