### PR TITLE
Fix missing values for some GSettings keys

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -101,12 +101,15 @@ const easing_options = [
 
 function getBaseString(translatedString) {
     switch (translatedString) {
+        case _("Flip Stack"): return "Flip Stack";
+        case _("Carousel"): return "Carousel";
         case _("Coverflow"): return "Coverflow";
         case _("Timeline"): return "Timeline";
         case _("Bottom"): return "Bottom";
         case _("Top"): return "Top";
         case _("Classic"): return "Classic";
         case _("Overlay"): return "Overlay";
+        case _("Attached"): return "Attached";
         default: return translatedString;
     }
 }


### PR DESCRIPTION
This fixes the warning about invalid values is shown in the journal like this:

```
gjs[12206]: g_settings_set_value: value for key 'switcher-looping-method' in schema 'org.gnome.shell.extensions.coverflowalttab' is outside of valid range
```