### PR TITLE
Add Gnome 47.rc

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
     "gettext-domain": "CoverflowAltTab@palatis.blogspot.com",
     "name": "Coverflow Alt-Tab",
     "settings-schema": "org.gnome.shell.extensions.coverflowalttab",
-    "shell-version": ["46"],
+    "shell-version": ["46", "47"],
     "uuid": "CoverflowAltTab@palatis.blogspot.com",
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",
     "url": "https://github.com/dsheeler/CoverflowAltTab"


### PR DESCRIPTION
Adding in 47 to the shell version works in 47.rc from my test's.