### PR TITLE
Use spaces indentation instead of a tab

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -54,9 +54,9 @@ export function debug(message) {
  * @return {void}
  */
 export function __ABSTRACT_METHOD__(object, method) {
-	throw new Error(
-		"Abstract method " +
-		object.constructor.name + "." + method.name + "()" +
-		" not implemented"
-	);
+  throw new Error(
+    "Abstract method " +
+    object.constructor.name + "." + method.name + "()" +
+    " not implemented"
+  );
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -184,29 +184,29 @@ export const Manager = class Manager {
                 isApplicationSwitcher = !this.platform.getSettings().switch_application_behaves_like_switch_windows
             default:
                 let currentOnly = this.platform.getSettings().current_workspace_only;
-              	if (currentOnly === 'all-currentfirst') {
+                if (currentOnly === 'all-currentfirst') {
                     // Switch between windows of all workspaces, prefer
-              		// those from current workspace
-              		let wins1 = windows.filter(matchWorkspace, currentWorkspace);
-              		let wins2 = windows.filter(matchOtherWorkspace, currentWorkspace);
+                    // those from current workspace
+                    let wins1 = windows.filter(matchWorkspace, currentWorkspace);
+                    let wins2 = windows.filter(matchOtherWorkspace, currentWorkspace);
                     // Sort by user time
                     wins1.sort(sortWindowsByUserTime);
                     wins2.sort(sortWindowsByUserTime);
                     windows = wins1.concat(wins2);
                     wins1 = [];
                     wins2 = [];
-              	} else {
-              	    let filter = currentOnly === 'current' ? matchWorkspace :
+                } else {
+                    let filter = currentOnly === 'current' ? matchWorkspace :
                           matchSkipTaskbar;
-            		// Switch between windows of current workspace
-               		windows = windows.filter(filter, currentWorkspace);
+                    // Switch between windows of current workspace
+                    windows = windows.filter(filter, currentWorkspace);
                     windows.sort(sortWindowsByUserTime);
                 }
                 break;
         }
 
         // filter by windows existing on the active monitor
-        if(this.platform.getSettings().switch_per_monitor)
+        if (this.platform.getSettings().switch_per_monitor)
         {
             windows = windows.filter ( (win) =>
               win.get_monitor() == Main.layoutManager.currentMonitor.index );

--- a/src/platform.js
+++ b/src/platform.js
@@ -147,8 +147,8 @@ class AbstractPlatform {
     }
 
     initBackground() {
-    	this._background = Meta.BackgroundActor.new_for_screen(global.screen);
-		this._background.hide();
+        this._background = Meta.BackgroundActor.new_for_screen(global.screen);
+        this._background.hide();
         global.overlay_group.add_child(this._background);
     }
 
@@ -162,7 +162,7 @@ class AbstractPlatform {
     }
 
     removeBackground() {
-    	global.overlay_group.remove_child(this._background);
+        global.overlay_group.remove_child(this._background);
     }
 }
 
@@ -531,13 +531,13 @@ export class PlatformGnomeShell extends AbstractPlatform {
     }
 
     initBackground() {
-    	this._backgroundGroup = new Meta.BackgroundGroup();
+        this._backgroundGroup = new Meta.BackgroundGroup();
         this._backgroundGroup.set_name("coverflow-alt-tab-background-group");
         Main.layoutManager.uiGroup.add_child(this._backgroundGroup);
-    	if (this._backgroundGroup.lower_bottom) {
-	        this._backgroundGroup.lower_bottom();
+        if (this._backgroundGroup.lower_bottom) {
+            this._backgroundGroup.lower_bottom();
         } else {
-	        Main.uiGroup.set_child_below_sibling(this._backgroundGroup, null);
+            Main.uiGroup.set_child_below_sibling(this._backgroundGroup, null);
         }
         
         this._backgroundShade = new Clutter.Actor({ 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -136,27 +136,27 @@ export default class CoverflowAltTabPreferences extends ExtensionPreferences {
         return _('Version %d').format(this.metadata.version);
     }
     
-	fillPreferencesWindow(window) {
-		let settings = this.getSettings();
-		let switcher_page = new Adw.PreferencesPage({
-			title: _('General'),
-			icon_name: 'general-symbolic',
-		});
+    fillPreferencesWindow(window) {
+        let settings = this.getSettings();
+        let switcher_page = new Adw.PreferencesPage({
+            title: _('General'),
+            icon_name: 'general-symbolic',
+        });
 
-		let switcher_pref_group = new Adw.PreferencesGroup({
-			title: _('Switcher Properties'),
-		});
-		let switcher_looping_method_buttons = new Map([ [_("Flip Stack"), [[],[]]], [_("Carousel"), [[],[]]]]);
+        let switcher_pref_group = new Adw.PreferencesGroup({
+            title: _('Switcher Properties'),
+        });
+        let switcher_looping_method_buttons = new Map([ [_("Flip Stack"), [[],[]]], [_("Carousel"), [[],[]]]]);
 
-		let switcher_looping_method_row = buildRadioAdw(settings, "switcher-looping-method", switcher_looping_method_buttons, _("Looping Method"), _("How to cycle through windows."));
-		switcher_pref_group.add(buildRadioAdw(settings, "switcher-style", new Map([ [_("Coverflow"), [[switcher_looping_method_row], []]], [_("Timeline"), [[],[switcher_looping_method_row]] ]]), _("Style"), _("Pick the type of switcher.")))
-		switcher_pref_group.add(buildSpinAdw(settings, "offset", [-500, 500, 1, 10], _("Vertical Offset"), _("Positive value moves everything down, negative up.")));
-		switcher_pref_group.add(buildRadioAdw(settings, "position", new Map([ [_("Bottom"), [[], []]], [_("Top"), [[],[]]]]), _("Window Title Position"), _("Place window title above or below the switcher.")));
-		switcher_pref_group.add(buildSwitcherAdw(settings, "enforce-primary-monitor", [], [], _("Enforce Primary Monitor"), _("Always show on the primary monitor, otherwise, show on the active monitor.")));
+        let switcher_looping_method_row = buildRadioAdw(settings, "switcher-looping-method", switcher_looping_method_buttons, _("Looping Method"), _("How to cycle through windows."));
+        switcher_pref_group.add(buildRadioAdw(settings, "switcher-style", new Map([ [_("Coverflow"), [[switcher_looping_method_row], []]], [_("Timeline"), [[],[switcher_looping_method_row]] ]]), _("Style"), _("Pick the type of switcher.")))
+        switcher_pref_group.add(buildSpinAdw(settings, "offset", [-500, 500, 1, 10], _("Vertical Offset"), _("Positive value moves everything down, negative up.")));
+        switcher_pref_group.add(buildRadioAdw(settings, "position", new Map([ [_("Bottom"), [[], []]], [_("Top"), [[],[]]]]), _("Window Title Position"), _("Place window title above or below the switcher.")));
+        switcher_pref_group.add(buildSwitcherAdw(settings, "enforce-primary-monitor", [], [], _("Enforce Primary Monitor"), _("Always show on the primary monitor, otherwise, show on the active monitor.")));
 
-		switcher_pref_group.add(switcher_looping_method_row);
-		switcher_pref_group.add(buildSwitcherAdw(settings, "hide-panel", [], [], _("Hide Panel"), _("Hide panel when switching windows.")));
-		switcher_pref_group.add(buildSwitcherAdw(settings, "invert-swipes", [], [], _("Invert Swipes"), _("Invert system scroll direction setting.")));
+        switcher_pref_group.add(switcher_looping_method_row);
+        switcher_pref_group.add(buildSwitcherAdw(settings, "hide-panel", [], [], _("Hide Panel"), _("Hide panel when switching windows.")));
+        switcher_pref_group.add(buildSwitcherAdw(settings, "invert-swipes", [], [], _("Invert Swipes"), _("Invert system scroll direction setting.")));
         switcher_page.add(switcher_pref_group);
 
         let background_pref_group = new Adw.PreferencesGroup({
@@ -207,7 +207,7 @@ export default class CoverflowAltTabPreferences extends ExtensionPreferences {
         let style_row = buildRadioAdw(settings, "icon-style", buttons, _("Application Icon Style"));
         let add_remove_effects_buttons = new Map([ [_("Fade Only"), [[],[]]], [_("Scale Only"), [[],[]]], [_("Fade and Scale"), [[],[]]]]);
 
-		let add_remove_effects_row = buildRadioAdw(settings, "icon-add-remove-effects", add_remove_effects_buttons, _("Add / Remove Effects"), _("How Icons and Labels ease in and out."));
+        let add_remove_effects_row = buildRadioAdw(settings, "icon-add-remove-effects", add_remove_effects_buttons, _("Add / Remove Effects"), _("How Icons and Labels ease in and out."));
         icon_pref_group.add(style_row);
         icon_pref_group.add(size_row);
         icon_pref_group.add(opacity_row);
@@ -619,7 +619,7 @@ function buildRangeAdw(settings, key, values, title, subtitle="", draw_value=fal
     let [min, max, step, defvs] = values;
 
     let pref = new Adw.ActionRow({
-        title: title,	
+        title: title,
     });
     if (subtitle !== null && subtitle !== "") {
         pref.set_subtitle(subtitle);

--- a/src/switcher.js
+++ b/src/switcher.js
@@ -881,7 +881,7 @@ export class Switcher {
         return true;
     }
     _windowDestroyed(wm, actor) {
-		this._removeDestroyedWindow(actor.meta_window);
+        this._removeDestroyedWindow(actor.meta_window);
     }
 
     _checkDestroyed(window) {


### PR DESCRIPTION
- Unify to use spaces indentation instead of a tab
- Add missing space after `if` and the begging parenthesis
- Remove extra tab in the end of the line