### PR TITLE
Fix missing translatable texts

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -200,7 +200,7 @@ export default class CoverflowAltTabPreferences extends ExtensionPreferences {
             title: _('Properties'),
         });
         animation_page.add(animation_pref_group);
-        animation_pref_group.add(buildDropDownAdw(settings, "easing-function", easing_options, "Easing Function", "Determine how windows move."));
+        animation_pref_group.add(buildDropDownAdw(settings, "easing-function", easing_options, _("Easing Function"), _("Determine how windows move.")));
         animation_pref_group.add(buildRangeAdw(settings, "animation-time", [0.01, 2, 0.001, [0.5, 1, 1.5]], _("Duration [s]"), "", true));
         animation_pref_group.add(buildSwitcherAdw(settings, "randomize-animation-times", [], [], _("Randomize Durations"), _("Each animation duration assigned randomly between 0 and configured duration.")));
 
@@ -393,8 +393,8 @@ export default class CoverflowAltTabPreferences extends ExtensionPreferences {
             description: _("Internal actions that will not conflict with other window switchers.")
         });
         keybinding_page.add(custom_keybinding_pref_group);
-        custom_keybinding_pref_group.add(buildShortcutButtonAdw(settings, "coverflow-switch-windows", "Coverflow Switch Windows Shortcut", "Activate winow switcher."));
-        custom_keybinding_pref_group.add(buildShortcutButtonAdw(settings, "coverflow-switch-applications", "Coverflow Switch Applications Shortcut", "Activate application switcher."));
+        custom_keybinding_pref_group.add(buildShortcutButtonAdw(settings, "coverflow-switch-windows", _("Coverflow Switch Windows Shortcut"), _("Activate winow switcher.")));
+        custom_keybinding_pref_group.add(buildShortcutButtonAdw(settings, "coverflow-switch-applications", _("Coverflow Switch Applications Shortcut"), _("Activate application switcher.")));
         
         let pcorrection_pref_group = new Adw.PreferencesGroup({
             title: _("Advanced Options"),
@@ -404,7 +404,7 @@ export default class CoverflowAltTabPreferences extends ExtensionPreferences {
             { id: "None", name: _("None") },
             { id: "Move Camera", name: _("Move Camera") },
             { id: "Adjust Angles", name: _("Adjust Angles") }],
-            _("Perspective Correction"), ("Method to make off-center switcher look centered.")));
+            _("Perspective Correction"), _("Method to make off-center switcher look centered.")));
 
         pcorrection_pref_group.add(buildSwitcherAdw(settings, "verbose-logging", [], [], _("Verbose Logging"), _("Log debug and normal messages.")));
         switcher_page.add(pcorrection_pref_group);

--- a/src/shortcutButton.js
+++ b/src/shortcutButton.js
@@ -8,6 +8,7 @@ import Gio from 'gi://Gio';
 import Gdk from 'gi://Gdk';
 import Adw from 'gi://Adw';
 
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js'
 
 export class ShortcutButton extends Gtk.Stack {
     static {
@@ -33,7 +34,7 @@ export class ShortcutButton extends Gtk.Stack {
         this.actionName = actionName;
 
         this.chooseButton = new Gtk.Button({
-            label: "Choose...",
+            label: _("Choose..."),
         });
 
         this.editBox = new Gtk.Box({
@@ -42,11 +43,11 @@ export class ShortcutButton extends Gtk.Stack {
         this.editBox.add_css_class("linked");
 
         this.changeButton = new Gtk.Button({
-            tooltip_text: "Change keyboard shortcut",
+            tooltip_text: _("Change keyboard shortcut"),
         })
 
         this.clearButton = new Gtk.Button({
-            label: "Clear",
+            label: _("Clear"),
         })
         this.clearButton.add_css_class("destructive-action");
 
@@ -86,7 +87,7 @@ export class ShortcutButton extends Gtk.Stack {
     openDialog() {
         if (this.dialog === null) {
             this.statusPage = new Adw.StatusPage({
-                title: "Press your keyboard shortcut...",
+                title: _("Press your keyboard shortcut..."),
                 icon_name: "preferences-desktop-keyboard-shortcuts-symbolic",
                 vexpand: true,
             })


### PR DESCRIPTION
This fixes the "Internal Actions Keybindings" section is not translatable and always shown in English regardless of the system language:

![Screenshot from 2024-09-08 09-12-59](https://github.com/user-attachments/assets/ed4576bd-c86d-4999-96b6-58d15439d34d)
